### PR TITLE
fix: remove broken include reference in Templates README

### DIFF
--- a/_gabarits-jsonld/README.md
+++ b/_gabarits-jsonld/README.md
@@ -3,8 +3,6 @@ title: Event Structured Data Templates
 layout: gabarits-doc
 nav_order: 2
 ---
-{% include gabarit-languages.html %}
-
 Event Structured Data Templates
 =====================================
 


### PR DESCRIPTION
Removed {% include gabarit-languages.html %} from _gabarits-jsonld/README.md — the file gabarit-languages.html does not exist in _includes/, causing Jekyll to throw a Liquid Exception and fail to build
The language switcher is already handled by the gabarits-doc layout, so the include was redundant in addition to being broken
