### PR TITLE
Clarify startDate format in event.jsonld

### DIFF
--- a/_gabarits-jsonld/Event/event.jsonld
+++ b/_gabarits-jsonld/Event/event.jsonld
@@ -7,7 +7,7 @@
    "sameAs":[
       "--lien vers une page sur un réseau social, si disponible : link to a social media page, if available--",
       "--URI Artsdata.ca, obtenu avec l'API de réconciliation ou l'outil de recherche : Artsdata.ca URI, obtained with the Reconciliation API or the search tool--"],
-   "startDate":"--Date et heure du début de l'événement, en format ISO 8601, par exemple 2025-03-15T19:30:00-05:00 : Date and time of the start of the event, in ISO 8601 format, for example 2025-03-15T19:30:00-05:00--",
+   "startDate":"--Date et heure du début de l'événement, en format ISO 8601, par exemple 2025-03-15T19:30:00-05:00. Le décalage horaire est optionnel. : Date and time of the start of the event, in ISO 8601 format, for example 2025-03-15T19:30:00-05:00. The time zone offset is optional.--",
    "location":[
          {
             "@type":"Place",


### PR DESCRIPTION
Updated the startDate field to clarify that the time zone offset is optional.