### PR TITLE
Add Artsdata Place Types Controlled Vocabulary draft

### DIFF
--- a/place-types.md
+++ b/place-types.md
@@ -1,0 +1,51 @@
+# Artsdata Place Types Controlled Vocabulary - DRAFT
+
+In addition to concepts from the Artsdata Place Types controlled vocabulary, Artsdata accepts Schema.org Event sub-types as well as Wikidata concepts.
+The following types of places have been designed by the LDFI project led by CAPACOA. 
+
+https://wikidata.org/wiki/Wikidata:WikiProject_Cultural_venues/Typology
+
+Artsdata highly recommends using the Wikidata type URI as schema:additionalType. 
+
+| CURI | Preferred label | Exact match | Close match |
+| - | - | - | - |
+| [PlaceConcept](http://kg.artsdata.ca/resource/PlaceConcept) | Concept of a place | schema:Place | |
+| [CultureRecreationalStructure](http://kg.artsdata.ca/resource/CultureRecreationalStructure) | Cultural & Recreational Structures | nom:659, aat:300424157 | |
+| [CivicSocialStructure](http://kg.artsdata.ca/resource/CivicSocialStructure) | Civic & Social Structures | nom:597 | |
+| [EventVenue](http://kg.artsdata.ca/resource/EventVenue) | Event venue | wd:Q18674739 |schema:EventVenue |
+| [Complex](http://kg.artsdata.ca/resource/Complex) | Complex | aat:300000202, wd:Q1497364 | |
+| [Structure](http://kg.artsdata.ca/resource/Structure) | Built work | aat:300265418, wd:Q811979 | |
+| [Building](http://kg.artsdata.ca/resource/Building) | Building | wd:Q41176, dbpedia:Building, aat:300004792 | |
+| [InteriorSpace](http://kg.artsdata.ca/resource/InteriorSpace) | Interior space | aat:300133704 |wd:Q1299240, schema:Room |
+| [PerformanceHall](http://kg.artsdata.ca/resource/PerformanceHall) | Performance hall | wd:Q112688641 |aat:300449028 |
+| [ItalianTheatre](http://kg.artsdata.ca/resource/ItalianTheatre) | Italian theatre | wd:Q18225059 | |
+| [ConcertHall](http://kg.artsdata.ca/resource/ConcertHall) | Concert hall | wd:Q10547643 | |
+| [ComedyClub](http://kg.artsdata.ca/resource/ComedyClub) | Comedy club | wd:Q2814066 | |
+| [BlackBox](http://kg.artsdata.ca/resource/BlackBox) | Black box theatre | wd:Q201946 | |
+| [TheatreInTheRound](http://kg.artsdata.ca/resource/TheatreInTheRound) | Theatre in the round | wd:Q7777493 | |
+| [Cabaret](http://kg.artsdata.ca/resource/Cabaret) | Cabaret | wd:Q131183, aat:300007099 | |
+| [RehearsalSpace](http://kg.artsdata.ca/resource/RehearsalSpace) | Rehearsal room | wd:Q1420179 | |
+| [MeetingSpace](http://kg.artsdata.ca/resource/MeetingSpace) | Meeting room | wd:Q133821658 |aat:300004398, schema:MeetingRoom |
+| [ExhibitionSpace](http://kg.artsdata.ca/resource/ExhibitionSpace) | Exhibition space | wd:Q15206795, aat:300240057 | |
+| [PerformingArtsBuilding](http://kg.artsdata.ca/resource/PerformingArtsBuilding) | Performing arts building | wd:Q57660343, aat:300132484 | |
+| [TheatreBuilding](http://kg.artsdata.ca/resource/TheatreBuilding) | Theatre building | wd:Q24354, aat:300007117 | |
+| [OperaHouse](http://kg.artsdata.ca/resource/OperaHouse) | Opera house | wd:Q153562, aat:300007104 | |
+| [Amphitheatre](http://kg.artsdata.ca/resource/Amphitheatre) | Amphitheatre | wd:Q54831, aat:300007128 | |
+| [PerformingArtsCentre](http://kg.artsdata.ca/resource/PerformingArtsCentre) | Performing arts centre | wd:Q3469910 | |
+| [MusicVenue](http://kg.artsdata.ca/resource/MusicVenue) | Music venue | wd:Q8719053, schema:MusicVenue | |
+| [NightClub](http://kg.artsdata.ca/resource/NightClub) | Night club | wd:Q622425 | |
+| [MovieTheatre](http://kg.artsdata.ca/resource/MovieTheatre) | Movie theatre | wd:Q41253, aat:300007135, schema:MovieTheater | |
+| [CulturalCentre](http://kg.artsdata.ca/resource/CulturalCentre) | Cultural centre | aat:300005135 |wd:Q1329623 |
+| [CommunityCentre](http://kg.artsdata.ca/resource/CommunityCentre) | Community centre | aat:300005120 |wd:Q77115 |
+| [HouseOfCulture](http://kg.artsdata.ca/resource/HouseOfCulture) | House of culture | wd:Q5061188 | |
+| [ConventionCentre](http://kg.artsdata.ca/resource/ConventionCentre) | Convention centre | wd:Q1378975 | |
+| [Library](http://kg.artsdata.ca/resource/Library) | Library | wd:Q856584, aat:300006824, nom:614 | |
+| [SportsVenue](http://kg.artsdata.ca/resource/SportsVenue) | Sports venue | wd:Q1076486 | |
+| [Stadium](http://kg.artsdata.ca/resource/Stadium) | Stadium | wd:Q483110 | |
+| [Arena](http://kg.artsdata.ca/resource/Arena) | Arena | wd:Q641226 | |
+| [OpenAirEventVenue](http://kg.artsdata.ca/resource/OpenAirEventVenue) | Open air event venue | wd:Q117187730 | |
+| [FairGround](http://kg.artsdata.ca/resource/FairGround) | Fair ground | wd:Q2948561 | |
+| [ExhibitionBuilding](http://kg.artsdata.ca/resource/ExhibitionBuilding) | Exhibition building | nom:668 | |
+| [MuseumBuilding](http://kg.artsdata.ca/resource/MuseumBuilding) | Museum building | wd:Q24699794, aat:300005768, nom:672 | |
+| [ArtGallery](http://kg.artsdata.ca/resource/ArtGallery) | Art gallery | aat:300005232 |wd:Q1007870, schema:ArtGallery |
+| [ReligiousBuilding](http://kg.artsdata.ca/resource/ReligiousBuilding) | Religious building | wd:Q16970, aat:300007391 |nom:585 |


### PR DESCRIPTION
This document outlines the Artsdata Place Types controlled vocabulary, including preferred labels and exact matches for various place types relevant to cultural venues.