### PR TITLE
Update usageNote URL in skos-place-types.ttl

### DIFF
--- a/ontology/skos-place-types.ttl
+++ b/ontology/skos-place-types.ttl
@@ -43,7 +43,7 @@ adr:ArtsdataPlaceTypes dcterms:hasFormat <https://raw.githubusercontent.com/cult
 	vann:example adr:EventVenue ;
 	vann:preferredNamespacePrefix "adr" ;
 	vann:preferredNamespaceUri <http://kg.artsdata.ca/resource/> ;
-	vann:usageNote <https://docs.artsdata.ca/classes/place.html> ;
+	vann:usageNote <https://docs.artsdata.ca/place-types.html> ;
 	schema:creator adr:K1-5, adr:K16-211 ;
 	schema:dateCreated "2026-02-11"^^xsd:date ;
 	schema:dateModified "2026-02-11"^^xsd:date ;


### PR DESCRIPTION
Updated URL to point to the newly published documentation page.